### PR TITLE
Add evaluate-actions command to inspect GitHub Actions workflows

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,6 +56,22 @@ For any new feature or command added to this repository, include the following i
 - Documentation: update relevant `README.md` files (package-level and repository-level) to document CLI flags, examples, and input/output shapes.
 - CI: update GitHub Actions/workflows if the feature requires new build, lint, or test steps, or additional secrets; add workflow changes to the same PR.
 
+### Enforcement and verification
+
+- Required: when adding or modifying CLI commands under `packages/gh-cleanup/src/commands/` the PR MUST update documentation as described below. If documentation is not updated the PR description must include a justification and a TODO for the follow-up docs change.
+- Documentation targets that MUST be updated for command changes:
+	- package-level README: `packages/gh-cleanup/README.md` (add the command entry, flags, and examples).
+	- repository-level README: `README.md` (update the high-level command list and pipeline examples where applicable).
+	- any `docs/*.md` or `.github/*` files that reference the command or its flags.
+- Verification: before merging, run a quick grep to ensure command name appears in documentation. Example:
+
+```bash
+# run from repo root - replace <cmd> with the command name
+grep -R "<cmd>" README.md packages/**/README.md docs || true
+```
+
+- Optional CI: maintainers are encouraged to add a lightweight `verify-docs` job to CI that fails when new commands are added without updating docs. See `docs/` for examples.
+
 Including these items ensures consistent reviews, reproducible builds, and clear usage for maintainers and users.
 
 ## Command File Change Policy

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository is a small monorepo with two primary packages and supporting docs:
 
 - packages/github-rest: a lightweight GitHub REST client and reusable helpers (endpoints, pagination, permissions). See [packages/github-rest/README.md](packages/github-rest/README.md) for usage and exported helpers.
-- packages/gh-cleanup: CLI tools that implement repository-cleanup features (commands: remove-forks, archive-stale-repos, delete-empty-repos, categorize-repos, summary). See [packages/gh-cleanup/README.md](packages/gh-cleanup/README.md) for CLI options and examples.
+- packages/gh-cleanup: CLI tools that implement repository-cleanup features (commands: remove-forks, archive-stale-repos, delete-empty-repos, categorize-repos, summary, evaluate-actions). See [packages/gh-cleanup/README.md](packages/gh-cleanup/README.md) for CLI options and examples.
 
 Docs and artifacts
 - `generated/` contains example or generated markdown outputs (e.g., catalogs and summaries) produced by the CLI for site consumption. These are intended as the site/content inputs for `dfberry.github.io` or similar static sites. To place the `generated` folder at the root of the repo, use `../../generated`.
@@ -156,6 +156,11 @@ Switches used:
 	- `--prompt=PATH`: override the prompt template file (otherwise searches upward for `.github/LLM_DESCRIBE_REPO_PROMPT.md`).
 	- `--openai-key=KEY`: supply OpenAI key; otherwise `OPENAI_API_KEY` env var is used.
 	- `--apply`: PATCH repository description and update topics on GitHub (destructive; requires `GH_TOKEN` with repo permissions).
+
+	- Evaluate GitHub Actions workflows (dry-run):
+	```bash
+	npm run start -w gh-cleanup -- evaluate-actions --out=../../generated/actions.json
+	```
 
 Debugging LLM calls
 - The describe commands support optional debug flags to record prompts and provider responses for inspection:

--- a/packages/gh-cleanup/README.md
+++ b/packages/gh-cleanup/README.md
@@ -46,6 +46,11 @@ Commands
   - Note: the summary now includes public/private totals and per-category public/private splits.
 
 - `describe-repo` / `describe-repos`
+  
+- `evaluate-actions`
+  - Inspect GitHub Actions workflows across repositories owned by the authenticated user and produce a per-repo report. For each workflow the output includes: file path (workflow YAML file), workflow `name`, `description` (if present in the workflow file), `created_at`, `last_run`, and `last_successful_run`.
+  - Flags: `--output=json|md`, `--out=<path>` (destination file), common flags from `parseBaseFlags()` (e.g. `--debug`, `--debug-dir`).
+  - Notes: this command queries the Actions workflow list and workflow runs; ensure the `GH_TOKEN` has `repo` or read scopes for private repos.
   - Generate short/long descriptions, suggested topics, and related links using an LLM.
   - Use `describe-repo` for a single repo and `describe-repos` for batch JSON inputs.
   - Flags:

--- a/packages/gh-cleanup/src/commands/evaluate-actions.ts
+++ b/packages/gh-cleanup/src/commands/evaluate-actions.ts
@@ -1,0 +1,166 @@
+/**
+ * Command: evaluate-actions
+ *
+ * Purpose:
+ *   Inspect GitHub Actions workflows across authenticated user's repositories
+ *   and report workflow file name, workflow name, description (if present in file),
+ *   create date, last run time, and last successful run time.
+ *
+ * Exports:
+ *   - `parseArgs(argv)`, `runCommand(client, args)`, `writeOutput(result, args)`
+ *   - `evaluateActionsCommand(argv)` — thin CLI wrapper used by the bin
+ */
+
+import { GitHubClient, repos, pagination } from 'github-rest';
+import { emitOutput, formatJsonOutput, addGeneratedTimestamp } from '../lib/report.js';
+import { parseBaseFlags, BaseFlags } from '../lib/flags.js';
+
+export type Args = BaseFlags & { output?: 'json' | 'md' };
+
+export function parseArgs(argv: string[]): Args {
+  const base = parseBaseFlags(argv);
+  const args: Args = { ...base, output: undefined };
+  for (const a of argv) {
+    if (a.startsWith('--output=')) args.output = (a.split('=')[1] as any) || undefined;
+  }
+  return args;
+}
+
+function decodeContent(encoded: string | undefined, encoding?: string | null): string | null {
+  if (!encoded) return null;
+  try {
+    if ((encoding ?? 'base64') === 'base64') {
+      return Buffer.from(encoded, 'base64').toString('utf8');
+    }
+    return encoded;
+  } catch (e) {
+    return null;
+  }
+}
+
+function extractDescriptionFromWorkflow(content: string | null): string | null {
+  if (!content) return null;
+  // naive YAML extraction: look for a top-level 'description:' key
+  const m = content.match(/^[ \t-]*description:\s*(?:"([^"]*)"|'([^']*)'|([^\n\r]*))/im);
+  if (!m) return null;
+  return (m[1] || m[2] || m[3] || '').trim();
+}
+
+export async function runCommand(client: GitHubClient, args: Args): Promise<any> {
+  const allRepos = await pagination.paginateAll(async (page) => {
+    return repos.listAuthenticatedUserRepos(client, page, 100);
+  });
+
+  const out: any[] = [];
+
+  for (const r of allRepos) {
+    const owner = r.owner.login;
+    const name = r.name;
+    try {
+      const wfRes: any = await client.get(`/repos/${owner}/${name}/actions/workflows`);
+      const workflows: any[] = (wfRes && wfRes.workflows) || [];
+      if (!workflows || workflows.length === 0) continue;
+
+      const repoEntry: any = { full_name: r.full_name, html_url: r.html_url, workflows: [] };
+
+      for (const wf of workflows) {
+        const wfEntry: any = {
+          file: wf.path ?? null,
+          name: wf.name ?? null,
+          created_at: wf.created_at ?? null,
+          description: null,
+          last_run: null,
+          last_successful_run: null,
+          html_url: wf.html_url ?? null,
+        };
+
+        // try to get description from workflow file contents
+        try {
+          const contents = await client.get(`/repos/${owner}/${name}/contents/${encodeURIComponent(wf.path)}`);
+          const decoded = decodeContent(contents?.content ?? contents?.raw_content, contents?.encoding);
+          const desc = extractDescriptionFromWorkflow(decoded);
+          if (desc) wfEntry.description = desc;
+        } catch (e) {
+          // ignore content fetch errors (private files, etc.)
+        }
+
+        // last run
+        try {
+          const runsRes: any = await client.get(`/repos/${owner}/${name}/actions/workflows/${wf.id}/runs?per_page=1`);
+          const runs = (runsRes && runsRes.workflow_runs) || [];
+          if (runs.length > 0) wfEntry.last_run = runs[0].created_at ?? runs[0].updated_at ?? null;
+        } catch (e) {
+          // ignore
+        }
+
+        // last successful run — search recent runs for a successful conclusion
+        try {
+          const runsRes2: any = await client.get(`/repos/${owner}/${name}/actions/workflows/${wf.id}/runs?per_page=50`);
+          const runs2 = (runsRes2 && runsRes2.workflow_runs) || [];
+          const success = runs2.find((rr: any) => rr.conclusion === 'success');
+          if (success) wfEntry.last_successful_run = success.created_at ?? success.updated_at ?? null;
+        } catch (e) {
+          // ignore
+        }
+
+        repoEntry.workflows.push(wfEntry);
+      }
+
+      out.push(repoEntry);
+    } catch (err: any) {
+      // skip repos where actions endpoint is not accessible
+      continue;
+    }
+  }
+
+  return { repos: out };
+}
+
+export async function writeOutput(result: any, args: Args) {
+  const data = (result && result.repos) || [];
+  if (args.output === 'md') {
+    // build markdown: index of repos, then H2 per repo with a table of workflows
+    const idxLines: string[] = [];
+    idxLines.push('# Actions Report\n');
+    idxLines.push('## Repository Index\n');
+    for (const r of data) {
+      const link = r.html_url ? `[${r.full_name}](${r.html_url})` : r.full_name;
+      idxLines.push(`- ${link}`);
+    }
+    idxLines.push('\n');
+
+    const sections: string[] = [];
+    for (const r of data) {
+      sections.push(`## ${r.full_name}`);
+      if (r.html_url) sections.push(`Repo: ${r.html_url}`);
+      sections.push('');
+      // table header
+      sections.push('| File | Name | Description | Created At | Last Run | Last Successful |');
+      sections.push('| --- | --- | --- | --- | --- | --- |');
+      for (const wf of r.workflows || []) {
+        const fileLink = wf.html_url ? `[${wf.file}](${wf.html_url})` : (wf.file || '');
+        const name = wf.name ?? '';
+        const desc = wf.description ? wf.description.replace(/\|/g, '\\|') : '';
+        const created = wf.created_at ?? '';
+        const lastRun = wf.last_run ?? '';
+        const lastSuccess = wf.last_successful_run ?? '';
+        sections.push(`| ${fileLink} | ${name} | ${desc} | ${created} | ${lastRun} | ${lastSuccess} |`);
+      }
+      sections.push('');
+    }
+
+    const md = addGeneratedTimestamp(idxLines.join('\n') + '\n' + sections.join('\n'), 'GitHub Actions Report');
+    await emitOutput(md, args.out || 'actions.md');
+    return;
+  }
+
+  // default: JSON
+  if (args.out) await emitOutput(formatJsonOutput(data), args.out);
+}
+
+export async function evaluateActionsCommand(argv: string[]) {
+  const args = parseArgs(argv);
+  const client = new GitHubClient({ token: process.env.GH_TOKEN, userAgent: 'gh-cleanup/evaluate-actions' });
+  const res = await runCommand(client, args);
+  await writeOutput(res, args);
+}

--- a/packages/gh-cleanup/src/lib/commands.ts
+++ b/packages/gh-cleanup/src/lib/commands.ts
@@ -29,6 +29,10 @@ const commands: Record<string, CommandRunner> = {
     const m = await import('../commands/delete-empty-repos.js');
     await m.deleteEmptyReposCommand(argv);
   },
+  'evaluate-actions': async (argv: string[]) => {
+    const m = await import('../commands/evaluate-actions.js');
+    await m.evaluateActionsCommand(argv);
+  },
 };
 
 export function availableCommands(): string[] {

--- a/scripts/run-all.sh
+++ b/scripts/run-all.sh
@@ -142,8 +142,18 @@ else
   echo "\n==> Skipping repository description step as OPENAI_API_KEY is not set." >&2
 fi
 
-# 6) Final log of activity
-# 5b) Final summary run after all operations (refresh active list + summary)
+# 5.5) Evaluate GitHub Actions workflows across active repositories
+#      - Produces $OUT_DIR/actions.md containing a Markdown table of per-repo
+#        workflow metadata (use --output=md to request table output)
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "\n==> Skipping evaluate-actions as GH_TOKEN is not set." >&2
+else
+  echo "\n==> Evaluating GitHub Actions workflows across repositories..." >&2
+  run_cmd "node \"$ROOT_DIR/packages/gh-cleanup/dist/bin/cli.js\" evaluate-actions --output=md --out=\"$OUT_DIR/actions.md\" --debug --debug-dir=\"$OUT_DIR/actions\""
+fi
+
+# 6a) Final log of activity
+# 6b) Final summary run after all operations (refresh active list + summary)
 run_cmd "node \"$ROOT_DIR/packages/gh-cleanup/dist/bin/cli.js\" summary --output=md --out=\"$OUT_DIR/summary-active.md\" --summary-out=\"$OUT_DIR/summary-report.md\" --debug --debug-dir=\"$OUT_DIR/llm\""
 
 echo "\nPipeline finished at: $(date -u --iso-8601=seconds)" >&2


### PR DESCRIPTION
- Introduced `evaluate-actions` command to audit workflows across repositories.
- Updated documentation to reflect new command and its usage.
- Enhanced run-all script to include evaluation of workflows.
- Added verification requirements for CLI command documentation updates.