### PR TITLE
Implement GitHub Actions governance workflow and refactor GitHub REST…

### DIFF
--- a/.github/workflows/repo-governance.yml
+++ b/.github/workflows/repo-governance.yml
@@ -1,0 +1,15 @@
+name: Repo Governance
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  verify-github-rest-usage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run verify-github-rest script
+        run: bash ./scripts/verify-github-rest.sh

--- a/packages/gh-cleanup/src/commands/evaluate-actions.ts
+++ b/packages/gh-cleanup/src/commands/evaluate-actions.ts
@@ -11,7 +11,7 @@
  *   - `evaluateActionsCommand(argv)` — thin CLI wrapper used by the bin
  */
 
-import { GitHubClient, repos, pagination } from 'github-rest';
+import { GitHubClient, repos, pagination, actions } from 'github-rest';
 import { emitOutput, formatJsonOutput, addGeneratedTimestamp } from '../lib/report.js';
 import { parseBaseFlags, BaseFlags } from '../lib/flags.js';
 
@@ -57,7 +57,7 @@ export async function runCommand(client: GitHubClient, args: Args): Promise<any>
     const owner = r.owner.login;
     const name = r.name;
     try {
-      const wfRes: any = await client.get(`/repos/${owner}/${name}/actions/workflows`);
+      const wfRes: any = await actions.listRepoWorkflows(client, owner, name);
       const workflows: any[] = (wfRes && wfRes.workflows) || [];
       if (!workflows || workflows.length === 0) continue;
 
@@ -76,17 +76,19 @@ export async function runCommand(client: GitHubClient, args: Args): Promise<any>
 
         // try to get description from workflow file contents
         try {
-          const contents = await client.get(`/repos/${owner}/${name}/contents/${encodeURIComponent(wf.path)}`);
-          const decoded = decodeContent(contents?.content ?? contents?.raw_content, contents?.encoding);
-          const desc = extractDescriptionFromWorkflow(decoded);
-          if (desc) wfEntry.description = desc;
+          if (wf.path) {
+            const contents = await actions.getRepoContent(client, owner, name, wf.path);
+            const decoded = decodeContent(contents?.content ?? contents?.raw_content, contents?.encoding);
+            const desc = extractDescriptionFromWorkflow(decoded);
+            if (desc) wfEntry.description = desc;
+          }
         } catch (e) {
           // ignore content fetch errors (private files, etc.)
         }
 
         // last run
         try {
-          const runsRes: any = await client.get(`/repos/${owner}/${name}/actions/workflows/${wf.id}/runs?per_page=1`);
+          const runsRes: any = await actions.listWorkflowRuns(client, owner, name, wf.id, 1);
           const runs = (runsRes && runsRes.workflow_runs) || [];
           if (runs.length > 0) wfEntry.last_run = runs[0].created_at ?? runs[0].updated_at ?? null;
         } catch (e) {
@@ -95,7 +97,7 @@ export async function runCommand(client: GitHubClient, args: Args): Promise<any>
 
         // last successful run — search recent runs for a successful conclusion
         try {
-          const runsRes2: any = await client.get(`/repos/${owner}/${name}/actions/workflows/${wf.id}/runs?per_page=50`);
+          const runsRes2: any = await actions.listWorkflowRuns(client, owner, name, wf.id, 50);
           const runs2 = (runsRes2 && runsRes2.workflow_runs) || [];
           const success = runs2.find((rr: any) => rr.conclusion === 'success');
           if (success) wfEntry.last_successful_run = success.created_at ?? success.updated_at ?? null;

--- a/packages/gh-cleanup/src/lib/describe-common.ts
+++ b/packages/gh-cleanup/src/lib/describe-common.ts
@@ -1,55 +1,11 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { callOpenAI, LLMConfig } from 'llm-completion';
-import { describeHelpers } from 'github-rest';
+import { describeHelpers, createGitHubClient } from 'github-rest';
 import { validateDescribeOutput } from './describe-validator.js';
 
 export function createClient(token?: string) {
-  const API = 'https://api.github.com';
-  const auth = token ? { Authorization: `token ${token}` } : {};
-  const fetchFn = (globalThis as any).fetch;
-  if (typeof fetchFn !== 'function') throw new Error('global fetch is not available');
-  const client: any = {};
-  client.request = async (method: string, path: string, opts: any = {}) => {
-      const url = path.startsWith('http') ? path : API + path;
-      const headers: Record<string,string> = {
-        Accept: 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-        'User-Agent': 'gh-cleanup/0.1',
-        ...(opts?.headers || {}),
-        ...auth
-      };
-      const init: any = { method, headers };
-      if (opts?.body !== undefined) {
-        init.body = typeof opts.body === 'string' ? opts.body : JSON.stringify(opts.body);
-        headers['Content-Type'] = headers['Content-Type'] ?? 'application/json';
-      }
-      const res = await fetchFn(url, init);
-      const rawHeaders: Record<string,string> = {};
-      res.headers.forEach((v: string, k: string) => rawHeaders[k.toLowerCase()] = v);
-      const contentType = res.headers.get('content-type') || '';
-      let body: any = undefined;
-      if (contentType.includes('application/json')) body = await res.json().catch(()=>undefined);
-      else body = await res.text().catch(()=>undefined);
-      if (!res.ok) throw Object.assign(new Error(`HTTP ${res.status} ${method} ${path}`), { status: res.status, body: body });
-      return { body, headers: rawHeaders, status: res.status };
-  };
-  client.rawRequest = async (method: string, path: string, opts: any = {}) => {
-    return await client.request(method, path, opts);
-  };
-  client.get = async (p: string, opts?: any) => {
-    const r = await client.request('GET', p, opts);
-    return r.body;
-  };
-  client.patch = async (p: string, body: any) => {
-    const r = await client.request('PATCH', p, { body });
-    return r.body;
-  };
-  client.put = async (p: string, body: any) => {
-    const r = await client.request('PUT', p, { body });
-    return r.body;
-  };
-  return client as any;
+  return createGitHubClient({ token, userAgent: 'gh-cleanup/0.1' });
 }
 
 export async function resolvePromptFile(promptFlag?: string) {

--- a/packages/github-rest/src/core/factory.ts
+++ b/packages/github-rest/src/core/factory.ts
@@ -1,0 +1,10 @@
+import { GitHubClient } from './client.js';
+
+export type CreateClientOptions = { token?: string; userAgent?: string };
+
+/**
+ * Create a configured `GitHubClient` instance.
+ */
+export function createGitHubClient(opts: CreateClientOptions = {}): GitHubClient {
+  return new GitHubClient({ token: opts.token, userAgent: opts.userAgent });
+}

--- a/packages/github-rest/src/endpoints/actions.ts
+++ b/packages/github-rest/src/endpoints/actions.ts
@@ -1,0 +1,34 @@
+import { GitHubClient } from '../core/client.js';
+
+/**
+ * List workflows for a repository. Returns the raw API response or `null` on error.
+ */
+export async function listRepoWorkflows(client: GitHubClient, owner: string, repo: string): Promise<any | null> {
+  try {
+    return await client.get<any>(`/repos/${owner}/${repo}/actions/workflows`);
+  } catch (err) {
+    return null;
+  }
+}
+
+/**
+ * Get a repository content entry by path. Returns the API response or `null` on error.
+ */
+export async function getRepoContent(client: GitHubClient, owner: string, repo: string, path: string): Promise<any | null> {
+  try {
+    return await client.get<any>(`/repos/${owner}/${repo}/contents/${encodeURIComponent(path)}`);
+  } catch (err) {
+    return null;
+  }
+}
+
+/**
+ * List workflow runs for a workflow id. Returns the raw API response or `null` on error.
+ */
+export async function listWorkflowRuns(client: GitHubClient, owner: string, repo: string, workflowId: string | number, per_page = 50): Promise<any | null> {
+  try {
+    return await client.get<any>(`/repos/${owner}/${repo}/actions/workflows/${workflowId}/runs?per_page=${per_page}`);
+  } catch (err) {
+    return null;
+  }
+}

--- a/packages/github-rest/src/index.ts
+++ b/packages/github-rest/src/index.ts
@@ -9,3 +9,6 @@ export { findEmptyRepos } from './endpoints/repos.js';
 export * as auth from './core/auth.js';
 export { getActorWithScopeCheck } from './core/auth.js';
 export * as describeHelpers from './endpoints/describe-helpers.js';
+export * as actions from './endpoints/actions.js';
+export { createGitHubClient } from './core/factory.js';
+

--- a/scripts/verify-github-rest.sh
+++ b/scripts/verify-github-rest.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify-github-rest.sh
+# ---------------------
+# Purpose:
+#   CI and local helper that scans the repository for direct HTTP usage
+#   (e.g. `client.get|post|patch|del`, `fetch(...)`, or local wrappers like
+#   `fetchFn(...)`) and enforces a project policy: all GitHub API requests
+#   should go through the centralized `packages/github-rest/src/endpoints`
+#   helpers. This keeps networking, authentication, retry, and mocking
+#   behavior consistent across packages.
+#
+# Scope & behavior:
+#   - Runs on PRs (via .github workflow) and can be run locally.
+#   - Only reports violations occurring inside `packages/gh-cleanup` by
+#     default; calls inside `packages/github-rest` internals and test files
+#     are ignored.
+#   - Detects common patterns, including wrapper assignments like
+#     `const fetchFn = (globalThis as any).fetch` and subsequent calls to
+#     the wrapper (e.g. `fetchFn(...)`).
+#
+# Whitelisting / Exceptions:
+#   - If a package must perform low-level fetches for a good reason, add a
+#     short code comment and update this script to allow that specific case,
+#     or move the helper into `packages/github-rest`.
+#
+# How to fix a violation:
+#   - Move the request into `packages/github-rest/src/endpoints` as a helper
+#     and call that helper from the caller; or use the exported `GitHubClient`
+#     or `createGitHubClient` factory from `github-rest`.
+
+echo "Scanning repository for direct client.* and fetch calls..."
+
+EXCLUDES=(--exclude-dir=.git --exclude-dir=node_modules --exclude-dir=dist)
+
+matches_client=$(grep -RInP ${EXCLUDES[@]} "client\\.(get|post|patch|del)\\s*\\(" --binary-files=without-match || true)
+matches_fetch=$(grep -RInP ${EXCLUDES[@]} "\\bfetch\\s*\\(|globalThis\\.fetch\\s*\\(" --binary-files=without-match || true)
+
+matches=""
+if [ -n "$matches_client" ]; then
+  matches+="$matches_client\n"
+fi
+if [ -n "$matches_fetch" ]; then
+  matches+="$matches_fetch\n"
+fi
+
+# Detect wrapper assignments like: const fetchFn = (globalThis as any).fetch
+# and then search for calls to those wrapper names (e.g. fetchFn(...)).
+wrapper_names=$(grep -RIP -o -h ${EXCLUDES[@]} "^(?:\s*)(?:const|let|var)\s+\K([A-Za-z_$][\\w$]*)(?=\s*=\s*[^\\n]*globalThis[^\\n]*\\.fetch)" --binary-files=without-match || true)
+if [ -n "$wrapper_names" ]; then
+  while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    # find calls to the wrapper name (respect excludes)
+    wrapper_calls=$(grep -RIn ${EXCLUDES[@]} -E "\b${name}\s*\(" --binary-files=without-match || true)
+    if [ -n "$wrapper_calls" ]; then
+      matches+="$wrapper_calls\n"
+    fi
+  done <<< "$wrapper_names"
+fi
+
+# Deduplicate matches (preserve first-seen order) to avoid duplicate reports
+if [ -n "$matches" ]; then
+  matches=$(printf '%s\n' "$matches" | awk '!seen[$0]++')
+fi
+
+if [ -z "${matches// /}" ]; then
+  echo "No direct client.* or fetch calls found."
+  exit 0
+fi
+
+violations=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  file=$(printf '%s' "$line" | cut -d: -f1)
+  # Only enforce in the gh-cleanup package; ignore other packages
+  if [[ "$file" != packages/gh-cleanup/* ]]; then
+    # still allow github-rest internals and test files anywhere
+    if [[ "$file" == packages/github-rest/src/endpoints/* || "$file" == packages/github-rest/src/core/* ]]; then
+      continue
+    fi
+    if [[ "$file" =~ \.test\.|/__tests__/ ]]; then
+      continue
+    fi
+    continue
+  fi
+  echo "Violation: $line"
+  violations=$((violations+1))
+done <<< "$matches"
+
+if [ "$violations" -gt 0 ]; then
+  echo "$violations violations found. Direct GitHubClient/fetch calls must be wrapped in packages/github-rest/src/endpoints."
+  exit 1
+fi
+
+echo "No violations found."
+exit 0
+
+
+# Deduplicate matches (preserve first-seen order) to avoid duplicate reports
+if [ -n "$matches" ]; then
+  matches=$(printf '%s\n' "$matches" | awk '!seen[$0]++')
+fi
+
+# Detect wrapper assignments like: const fetchFn = (globalThis as any).fetch
+# and then search for calls to those wrapper names (e.g. fetchFn(...)).
+wrapper_names=$(grep -RIP -o -h ${EXCLUDES[@]} "^(?:\s*)(?:const|let|var)\s+\K([A-Za-z_$][\\w$]*)(?=\s*=\s*[^\\n]*globalThis[^\\n]*\\.fetch)" --binary-files=without-match || true)
+if [ -n "$wrapper_names" ]; then
+  while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    # find calls to the wrapper name
+    wrapper_calls=$(grep -RIn --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=dist -E "\b${name}\s*\(" || true)
+    if [ -n "$wrapper_calls" ]; then
+      matches+="$wrapper_calls\n"
+    fi
+  done <<< "$wrapper_names"
+fi
+
+if [ -z "${matches// /}" ]; then
+  echo "No direct client.* or fetch calls found."
+  exit 0
+fi
+
+violations=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  file=$(printf '%s' "$line" | cut -d: -f1)
+  # Only enforce in the gh-cleanup package; ignore other packages
+  if [[ "$file" != packages/gh-cleanup/* ]]; then
+    wrapper_calls=$(grep -RIn ${EXCLUDES[@]} -E "\b${name}\s*\(" --binary-files=without-match || true)
+    if [[ "$file" == packages/github-rest/src/endpoints/* || "$file" == packages/github-rest/src/core/* ]]; then
+      continue
+    fi
+    if [[ "$file" =~ \.test\.|/__tests__/ ]]; then
+      continue
+    fi
+    continue
+  fi
+  echo "Violation: $line"
+  violations=$((violations+1))
+done <<< "$matches"
+
+if [ "$violations" -gt 0 ]; then
+  echo "$violations violations found. Direct GitHubClient/fetch calls must be wrapped in packages/github-rest/src/endpoints."
+  exit 1
+fi
+
+echo "No violations found."
+exit 0


### PR DESCRIPTION
This pull request introduces a project-wide policy to ensure all GitHub API requests in the `gh-cleanup` package go through centralized helper functions in `github-rest`, rather than making direct HTTP or client calls. It adds a CI workflow and script to enforce this, refactors code to use new helper functions, and introduces new endpoint helpers for GitHub Actions-related API calls.

**Enforcement of centralized API usage:**

* Added a `.github/workflows/repo-governance.yml` workflow and the `scripts/verify-github-rest.sh` script to scan for and block direct HTTP or client calls in `gh-cleanup`, enforcing use of centralized endpoint helpers. [[1]](diffhunk://#diff-f5c38dfaa521eccbdfe138ee9817d86a3dc843c5052ebd66ca06b3e494ae3aaeR1-R15) [[2]](diffhunk://#diff-7b7cc6ce41884cda0623813c9b8f20a8532f9b27352479a8aee5736d04fd2894R1-R149)

**Refactoring to use endpoint helpers:**

* Refactored `packages/gh-cleanup/src/commands/evaluate-actions.ts` to replace direct `client.get` calls with new `actions` endpoint helpers for listing workflows, fetching workflow file contents, and listing workflow runs. [[1]](diffhunk://#diff-f72bf4816aa16bc972c7f3b2c7fd68cb26034a0fa4f42c66321344f9d0c39672L14-R14) [[2]](diffhunk://#diff-f72bf4816aa16bc972c7f3b2c7fd68cb26034a0fa4f42c66321344f9d0c39672L60-R60) [[3]](diffhunk://#diff-f72bf4816aa16bc972c7f3b2c7fd68cb26034a0fa4f42c66321344f9d0c39672L79-R91) [[4]](diffhunk://#diff-f72bf4816aa16bc972c7f3b2c7fd68cb26034a0fa4f42c66321344f9d0c39672L98-R100)

**New endpoint helpers and exports:**

* Added new helpers in `packages/github-rest/src/endpoints/actions.ts` for listing repo workflows, getting workflow file contents, and listing workflow runs; exported these from the main `github-rest` entry point. [[1]](diffhunk://#diff-2fb25bce02e5828911bba5e94d87e920dac89ade34e021b03a200cf372b6a833R1-R34) [[2]](diffhunk://#diff-835cded0596ea33ae683d62a4215ed7870fe337a1aa1f1ad6c7a22e6c380015eR12-R14)

**Client creation improvements:**

* Replaced a local GitHub client implementation in `packages/gh-cleanup/src/lib/describe-common.ts` with the new `createGitHubClient` factory function from `github-rest` for consistency and maintainability. [[1]](diffhunk://#diff-482004095e88bf291d517f7e1ac02c0a1735950af0d4bb8a3ff61c9877fdc2b3L4-R8) [[2]](diffhunk://#diff-5cc6562f946c26c08c9522d4d13226c0d6743d8d67ad2b506763148326d092caR1-R10) [[3]](diffhunk://#diff-835cded0596ea33ae683d62a4215ed7870fe337a1aa1f1ad6c7a22e6c380015eR12-R14)… client usage